### PR TITLE
T3T-3741 feat: add example to create contact detail permissions

### DIFF
--- a/examples/collection.php
+++ b/examples/collection.php
@@ -131,6 +131,14 @@ if (!empty($collection)) {
                 $element->getRoomType()->getName(),
                 $element->getRoomType()->getSleeps()
             );
+        } elseif ($element instanceof tabs\apiclient\actor\Permission) {
+            echo sprintf(
+                '<li>%s - %s<br />%s - %s</li>',
+                $element->getMarketingbrand()->getName(),
+                $element->getContactdetail()->getValue(),
+                $element->getGranted() ? 'GRANTED' : 'NOT GRANTED',
+                $element->getGranteddatetime()->format('Y-m-d')
+            );
         } else {
             echo sprintf(
                 '<li><a href="../exploreelement/?q=%s">%s</a></li>',

--- a/examples/owner/add-contact-permission.php
+++ b/examples/owner/add-contact-permission.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @name Add contact detail permission to an owner
+ *
+ * This file documents how to add a contact detail permission record to an owner.
+ */
+
+require_once __DIR__ . '/../creating-a-new-connection.php';
+
+try {
+    if ($id = filter_input(INPUT_GET, 'id')) {
+        $owner = new tabs\apiclient\Owner($id);
+        $owner->get();
+
+        echo '<h3>Owner</h3>';
+        echo sprintf('<p>%s</p>', htmlspecialchars((string) $owner));
+
+        // grab contact details and filter to find emails
+        $contactDetails = $owner->getContactdetails()->filter(function($cd) {
+            return $cd->getType() == 'C' && $cd->getContactmethodtype() == 'Email';
+        });
+
+        // create new contact detail permission
+        $me = tabs\apiclient\client\Client::getClient()->whoami();
+
+        $permission = new \tabs\apiclient\actor\Permission();
+        $permission->setParent($owner);
+        $permission->setContactdetail($contactDetails->first());
+        $permission->setMarketingbrand(new \tabs\apiclient\Marketingbrand(6));
+        $permission->setGrantedbyactor($me);
+        $permission->create();
+
+        echo sprintf(
+            '<p>Contact detail permission added for %s</p>',
+            $contactDetails->first()->getValue()
+        );
+    }
+} catch (Exception $e) {
+    echo $e->getMessage();
+}
+
+require_once __DIR__ . '/../finally.php';

--- a/examples/owner/index.php
+++ b/examples/owner/index.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @name Accessing owner data
+ *
+ * This file documents how to request owner data.
+ */
+
+require_once __DIR__ . '/../creating-a-new-connection.php';
+
+try {
+    if ($id = filter_input(INPUT_GET, 'id')) {
+        $owner = new tabs\apiclient\Owner($id);
+        $owner->get();
+
+        echo '<h3>Owner</h3>';
+        echo sprintf('<p>%s</p>', htmlspecialchars((string) $owner));
+
+        if ($owner->getBankaccounts()->count() > 0) {
+            $collection = $owner->getBankaccounts();
+
+            include __DIR__ . '/../collection.php';
+        }
+
+        echo '<h3>Notes</h3>';
+        if ($owner->getNotes()->count() > 0) {
+            foreach ($owner->getNotes() as $note) {
+                echo sprintf(
+                    '<p>%s</p>',
+                    $note->getNote()
+                );
+            }
+        }
+
+        if ($owner->getContactdetails()->count() > 0) {
+            echo '<h3>Contact Details</h3>';
+
+            $collection = $owner->getContactdetails();
+
+            include __DIR__ . '/../collection.php';
+        }
+
+        // Get owner contact permission
+        $collection = $owner->getContactdetailpermissions();
+        include __DIR__ . '/../collection.php';
+        echo sprintf(
+            '<p><a href="add-contact-permission.php?id=%s">Add contact permission</a></p>',
+            $id
+        );
+
+        // Get the customer contacts
+        $collection = tabs\apiclient\Collection::factory(
+            new \tabs\apiclient\Contact
+        );
+        $collection->addFilter('recipientid', $owner->getId())
+            ->addFilter('contactentitytype', 'Owner')
+            ->fetch();
+        include __DIR__ . '/../collection.php';
+
+        if ($owner->getDocuments()->count() > 0) {
+            echo '<h3>Documents</h3>';
+            foreach ($owner->getDocuments()->getElements() as $doc) {
+                echo sprintf(
+                    '<p><a href="../document/viewing-a-document.php?id=%s">%s</a></p>',
+                    $doc->getDocument()->getId(),
+                    $doc->getDocument()->getName()
+                );
+            }
+        }
+    }
+} catch (Exception $e) {
+    echo $e->getMessage();
+}
+
+require_once __DIR__ . '/../finally.php';

--- a/src/tabs/apiclient/Owner.php
+++ b/src/tabs/apiclient/Owner.php
@@ -140,9 +140,9 @@ class Owner extends Actor
      *
      * @return boolean
      */
-    public function getAroard()
+    public function getAbroad()
     {
-        return $this->aroard;
+        return $this->abroad;
     }
 
     /**

--- a/src/tabs/apiclient/actor/Permission.php
+++ b/src/tabs/apiclient/actor/Permission.php
@@ -85,6 +85,17 @@ class Permission extends Builder
      */
     public function getContactdetail()
     {
+        switch ($this->contactdetail->getType()) {
+            case 'F':
+                return \tabs\apiclient\actor\PhoneNumber::factory($this->getResponsedata()->contactdetail);
+
+            case 'P':
+                return \tabs\apiclient\actor\Address::factory($this->getResponsedata()->contactdetail);
+
+            case 'C':
+                return \tabs\apiclient\actor\ContactDetailOther::factory($this->getResponsedata()->contactdetail);
+        }
+
         return $this->contactdetail;
     }
 


### PR DESCRIPTION
I modified the Permissions entity to return the correct type from getContactdetail - don't know if that's the correct way to do it? 

It's actually not going to be needed by the webform anyway, but I used it to get at the email address in the Actor example which lists the permissions.