### PR TITLE
Feat: add filter and mark findBy as deprecated as per StaticCollection

### DIFF
--- a/src/tabs/apiclient/Collection.php
+++ b/src/tabs/apiclient/Collection.php
@@ -90,15 +90,23 @@ class Collection extends StaticCollection
     }
 
     /**
-     * @inheritDoc
+     * @deprecated Deprecated in favour of filter()
      */
     public function findBy(callable $fn)
+    {
+        return $this->filter($fn);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function filter(callable $fn)
     {
         if (!$this->isFetched()) {
             $this->fetch();
         }
 
-        return parent::findBy($fn);
+        return parent::filter($fn);
     }
 
     /**


### PR DESCRIPTION
Not sure if this is needed or why filter() was added to StaticCollection and findBy() marked as deprecated, but it triggers the deprecation checks in phpStan